### PR TITLE
fix(eslint): add rule to ignore misused promises

### DIFF
--- a/library.js
+++ b/library.js
@@ -39,6 +39,15 @@ module.exports = {
   rules: {
     "@typescript-eslint/adjacent-overload-signatures": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        checksVoidReturn: {
+          arguments: false,
+          attributes: false,
+        },
+      },
+    ],
     "@typescript-eslint/sort-type-constituents": "off",
     "import/no-default-export": "off",
     "import/order": "off",


### PR DESCRIPTION
Added a new rule to the ESLint configuration to ignore misused promises. This rule checks for improper usage of promises and prevents potential issues. The rule has been configured to ignore certain cases where void return is used. This change helps improve code quality and maintainability.